### PR TITLE
Fix TODO card visual styling to distinguish expanded from collapsed states

### DIFF
--- a/src/components/ProjectCard.svelte
+++ b/src/components/ProjectCard.svelte
@@ -30,7 +30,18 @@
   }
 </script>
 
-<div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden">
+<div 
+  class="rounded-xl shadow-sm border overflow-hidden transition-all duration-300"
+  class:bg-white={!expanded}
+  class:dark:bg-gray-800={!expanded}
+  class:border-gray-200={!expanded}
+  class:dark:border-gray-700={!expanded}
+  class:bg-indigo-50={expanded}
+  class:dark:bg-indigo-900/20={expanded}
+  class:border-indigo-200={expanded}
+  class:dark:border-indigo-700={expanded}
+  class:shadow-lg={expanded}
+>
   <div class="p-6">
     <div class="flex items-start justify-between mb-4">
       <div class="flex-1">


### PR DESCRIPTION
Fixes the TODO collapsing visual issue where all project cards appeared identical regardless of their expanded/collapsed state.

## Changes
- Add conditional background and border styling for expanded vs collapsed cards
- Expanded cards now show indigo-tinted background and borders
- Collapsed cards maintain original neutral styling
- Added smooth transition animation between states

## Visual Changes
**Collapsed cards:**
- `bg-white dark:bg-gray-800` (neutral background)
- `border-gray-200 dark:border-gray-700` (gray borders)
- `shadow-sm` (subtle shadow)

**Expanded cards:**
- `bg-indigo-50 dark:bg-indigo-900/20` (highlighted background)
- `border-indigo-200 dark:border-indigo-700` (indigo borders)
- `shadow-lg` (elevated shadow)
- `transition-all duration-300` (smooth animation)

Fixes #6

Generated with [Claude Code](https://claude.ai/code)